### PR TITLE
Mention AUR on installation part of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ Well, glad you asked!
   Keep in mind that Glasscord may work with other CSS loaders and client mods too.
   
   After you installed the CSS loader properly, you can continue following this guide.
-- If you are using Arch linux or manjaro you can install Glasscord from the AUR instead of following this guide.
-	- [glasscord](https://aur.archlinux.org/packages/glasscord/)
-	- [glasscord-git](https://aur.archlinux.org/packages/glasscord-git/)
-	- [glasscord-bin](https://aur.archlinux.org/packages/glasscord-bin/)
+  
+- If you are using Arch or Manjaro you may install `glasscord`, `glasscord-git` or `glasscord-bin` from the AUR instead of the following steps.
+  	
 - Look in the Releases section for the latest released version of Glasscord. Download the `glasscord.asar` file from there.
 - Locate your Discord Desktop Core module folder. In the respective file paths, `x.x.x` corresponds to the version number.
   - On Windows, it is `%AppData%\discord\x.x.x\modules\discord_desktop_core\`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Well, glad you asked!
   Keep in mind that Glasscord may work with other CSS loaders and client mods too.
   
   After you installed the CSS loader properly, you can continue following this guide.
+- If you are using Arch linux or manjaro you can install Glasscord from the AUR instead of following this guide.
+	- [glasscord](https://aur.archlinux.org/packages/glasscord/)
+	- [glasscord-git](https://aur.archlinux.org/packages/glasscord-git/)
+	- [glasscord-bin](https://aur.archlinux.org/packages/glasscord-bin/)
 - Look in the Releases section for the latest released version of Glasscord. Download the `glasscord.asar` file from there.
 - Locate your Discord Desktop Core module folder. In the respective file paths, `x.x.x` corresponds to the version number.
   - On Windows, it is `%AppData%\discord\x.x.x\modules\discord_desktop_core\`


### PR DESCRIPTION
I've added installation/build scripts for Glasscord on the AUR and thought that it might be helpful for people to know they can install it that way.