### PR TITLE
README.md for dummies revamp - Blur Bogaloo update

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Well, glad you asked!
 - Locate your Electron app installation folder. We will assume it being the root directory from now on.
 - Locate the `resources` folder. Inside it you'll likely have an `app.asar` file **OR** an `app` folder.
 
-# THIS PART OF THE INSTALLATION DEPEND ON YOUR INSTALLED DISCORD APPLICATION, DON´T FOLLOW BOTH CASE STEPS
+# THIS PART OF THE INSTALLATION DEPEND ON YOUR INSTALLED DISCORD APPLICATION, DON'T FOLLOW BOTH CASE STEPS
 
 #### Case 1: you have an `app.asar` file
 - Create an `app` folder.
@@ -79,13 +79,13 @@ The Glasscord own CSS Loader is currently depreceated in the current state for D
 
 So you will have to use a third party CSS loader to load Discord themes.
 
-If you don´t have one installed, please install it FIRST, then install Glasscord AFTER you completed the other installation.
+If you don't have one installed, please install it FIRST, then install Glasscord AFTER you completed the other installation.
 
 Doing otherwise MAY BREAK the ability of the third party CSS loader to auto-update itself, so be warned!
 
 The default glasscord theme are adapted for [Powercord](https://github.com/powercord-org/powercord) usage, but [BeautifulDiscord](https://github.com/leovoel/BeautifulDiscord), [EnhancedDiscord](https://github.com/joe27g/EnhancedDiscord) and [BandagedBetterDiscord](https://github.com/rauenzi/BetterDiscordApp) work as well.
 
-The root discord electron installation folder is habitually situated in :
+The root Discord electron installation folder is habitually situated in :
 
         - Windows: `%appdata%/discord/app-*`; take the latest app version number if you have multiple ones.;
         - Linux: `/opt/discord/`; this may vary depending of your distribution as it may also be situated in `/usr/share/discord`. It may vary if you´ve installed Glasscord on a Snap/Flatpak package.
@@ -117,7 +117,7 @@ Here's a straightforward CSS properties explaination. Let's go through them one 
 #### accepts a value between those ones: `acrylic`, `blurbehind`, `transparent`; defaults to `acrylic`
 Sets the blur type on Windows.
 - `acrylic` refers to the strong blur used in Microsoft's Fluent Design. Note: it can be slow when
-dragging/resizing on some Windows versions, this is a Windows compositor own problem, not a glasscord one.
+dragging/resizing on some Windows versions, this is a Windows compositor own problem, not a Glasscord one.
 - `blurbehind` is a weaker blur than the other one, and it kinda resembles the good old Aero Glass effect.
 - `transparent` means no blur at all, so the window is just transparent..
 
@@ -146,7 +146,7 @@ Tells the window compositor whether to blur behind windows or not.
 **Note:** Check the Glasstron project to see which window servers/managers are compatible
 
 ## How do i compile it ?
-It is as simple as doing `npm -i` from the glasscord folder.
+It is as simple as doing `npm -i` from the Glasscord folder.
 
 ## I want to contribute to this madness!
 Did you find a bug? File it in the issues section!

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The default glasscord theme are adapted for [Powercord](https://github.com/power
 
 The root Discord electron installation folder is habitually situated in :
 
-        - Windows: `%appdata%/discord/app-*`; take the latest app version number if you have multiple ones.;
+        - Windows: `%appdata%/discord/app-*`; take the latest app version number if you have multiple ones.
         - Linux: `/opt/discord/`; this may vary depending of your distribution as it may also be situated in `/usr/share/discord`. It may vary if you´ve installed Glasscord on a Snap/Flatpak package.
         - macOS: `~/Library/Application Support/discord`.
 

--- a/README.md
+++ b/README.md
@@ -35,16 +35,20 @@ _TL;DR: Help me I have no purpose in this life anymore_
 ## How do I install it?
 Well, glad you asked!
 
-- Look in the Releases section for the latest released version of Glasscord. Download the `glasscord.asar` file from there.
+- Look in the Releases section for the latest released version of Glasscord. [Download the `glasscord.asar` file from there](https://github.com/AryToNeX/Glasscord/releases/latest/download/glasscord.asar).
 - Locate your Electron app installation folder. We will assume it being the root directory from now on.
-- Locate the `resources` folder. Inside it you'll likely have an `app.asar` file OR an `app` folder.
+- Locate the `resources` folder. Inside it you'll likely have an `app.asar` file **OR** an `app` folder.
+
+# THIS PART OF THE INSTALLATION DEPEND ON YOUR INSTALLED DISCORD APPLICATION, DON´T FOLLOW BOTH CASE STEPS
 
 #### Case 1: you have an `app.asar` file
 - Create an `app` folder.
 - Now you need to get the `package.json` file from the `app.asar` file.
   The best and quickest way to extract it via the `asar` command line tool.
   
-  If you don't have it, install it via `sudo npm install -g --engine-strict asar`.
+  If you don't have it, install it via `npm install -g --engine-strict asar`. *This may require administrative rights*.
+  
+  *You will have to install [node.js](https://nodejs.org) on your system to use npm commands*.
   
   Run this script where the `app.asar` file is:
   ```
@@ -71,9 +75,21 @@ Well, glad you asked!
 
 #### Notes for Discord
 
-You can use a third party CSS loader to load Discord themes.
-If that's the case, please install it FIRST, then install Glasscord AFTER you completed the other installation.
-This MAY BREAK the ability of the third party CSS loader to auto-update itself, so be warned!
+The Glasscord own CSS Loader is currently depreceated in the current state for Discord usage.
+
+So you will have to use a third party CSS loader to load Discord themes.
+
+If you don´t have one installed, please install it FIRST, then install Glasscord AFTER you completed the other installation.
+
+Doing otherwise MAY BREAK the ability of the third party CSS loader to auto-update itself, so be warned!
+
+The default glasscord theme are adapted for [Powercord](https://github.com/powercord-org/powercord) usage, but [BeautifulDiscord](https://github.com/leovoel/BeautifulDiscord), [EnhancedDiscord](https://github.com/joe27g/EnhancedDiscord) and [BandagedBetterDiscord](https://github.com/rauenzi/BetterDiscordApp) work as well.
+
+The root discord electron installation folder is habitually situated in :
+
+        - Windows: `%appdata%/discord/app-*`; take the latest app version number if you have multiple ones.;
+        - Linux: `/opt/discord/`; this may vary depending of your distribution as it may also be situated in `/usr/share/discord`. It may vary if you´ve installed Glasscord on a Snap/Flatpak package.
+        - macOS: `~/Library/Application Support/discord`.
 
 ## How do I USE it?
 Assuming you already installed everything correctly, you will need to load a custom CSS theme which supports Glasscord.
@@ -101,7 +117,7 @@ Here's a straightforward CSS properties explaination. Let's go through them one 
 #### accepts a value between those ones: `acrylic`, `blurbehind`, `transparent`; defaults to `acrylic`
 Sets the blur type on Windows.
 - `acrylic` refers to the strong blur used in Microsoft's Fluent Design. Note: it can be slow when
-dragging/resizing on some Windows versions.
+dragging/resizing on some Windows versions, this is a Windows compositor own problem, not a glasscord one.
 - `blurbehind` is a weaker blur than the other one, and it kinda resembles the good old Aero Glass effect.
 - `transparent` means no blur at all, so the window is just transparent..
 
@@ -128,6 +144,9 @@ If set to `none`, the vibrancy effect will not be applied but the window will be
 Tells the window compositor whether to blur behind windows or not.
 
 **Note:** Check the Glasstron project to see which window servers/managers are compatible
+
+## How do i compile it ?
+It is as simple as doing `npm -i` from the glasscord folder.
 
 ## I want to contribute to this madness!
 Did you find a bug? File it in the issues section!

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Well, glad you asked!
 - Locate your Electron app installation folder. We will assume it being the root directory from now on.
 - Locate the `resources` folder. Inside it you'll likely have an `app.asar` file **OR** an `app` folder.
 
-# THIS PART OF THE INSTALLATION DEPEND ON YOUR INSTALLED DISCORD APPLICATION, DON'T FOLLOW BOTH CASE STEPS
+# THIS PART OF THE INSTALLATION DEPENDS ON YOUR INSTALLED DISCORD APPLICATION, DON'T FOLLOW BOTH CASE STEPS
 
 #### Case 1: you have an `app.asar` file
 - Create an `app` folder.
@@ -48,7 +48,7 @@ Well, glad you asked!
   
   If you don't have it, install it via `npm install -g --engine-strict asar`. *This may require administrative rights*.
   
-  *You will have to install [node.js](https://nodejs.org) on your system to use npm commands*.
+  *You will have to install [Node.js](https://nodejs.org) on your system to use npm commands*.
   
   Run this script where the `app.asar` file is:
   ```
@@ -72,24 +72,6 @@ Well, glad you asked!
   }
   ```
 - If everything was done correctly, the Electron app should start and Glasscord should be injected.
-
-#### Notes for Discord
-
-The Glasscord own CSS Loader is currently depreceated in the current state for Discord usage.
-
-So you will have to use a third party CSS loader to load Discord themes.
-
-If you don't have one installed, please install it FIRST, then install Glasscord AFTER you completed the other installation.
-
-Doing otherwise MAY BREAK the ability of the third party CSS loader to auto-update itself, so be warned!
-
-The default glasscord theme are adapted for [Powercord](https://github.com/powercord-org/powercord) usage, but [BeautifulDiscord](https://github.com/leovoel/BeautifulDiscord), [EnhancedDiscord](https://github.com/joe27g/EnhancedDiscord) and [BandagedBetterDiscord](https://github.com/rauenzi/BetterDiscordApp) work as well.
-
-The root Discord electron installation folder is habitually situated in :
-
-        - Windows: `%appdata%/discord/app-*`; take the latest app version number if you have multiple ones.
-        - Linux: `/opt/discord/`; this may vary depending of your distribution as it may also be situated in `/usr/share/discord`. It may vary if you´ve installed Glasscord on a Snap/Flatpak package.
-        - macOS: `~/Library/Application Support/discord`.
 
 ## How do I USE it?
 Assuming you already installed everything correctly, you will need to load a custom CSS theme which supports Glasscord.
@@ -117,7 +99,7 @@ Here's a straightforward CSS properties explaination. Let's go through them one 
 #### accepts a value between those ones: `acrylic`, `blurbehind`, `transparent`; defaults to `acrylic`
 Sets the blur type on Windows.
 - `acrylic` refers to the strong blur used in Microsoft's Fluent Design. Note: it can be slow when
-dragging/resizing on some Windows versions, this is a Windows compositor own problem, not a Glasscord one.
+dragging/resizing on some Windows versions. This is a bug on Windows' side, so please don't report it on the issue tracker.
 - `blurbehind` is a weaker blur than the other one, and it kinda resembles the good old Aero Glass effect.
 - `transparent` means no blur at all, so the window is just transparent..
 
@@ -144,9 +126,6 @@ If set to `none`, the vibrancy effect will not be applied but the window will be
 Tells the window compositor whether to blur behind windows or not.
 
 **Note:** Check the Glasstron project to see which window servers/managers are compatible
-
-## How do i compile it ?
-It is as simple as doing `npm -i` from the Glasscord folder.
 
 ## I want to contribute to this madness!
 Did you find a bug? File it in the issues section!


### PR DESCRIPTION
- Added direct link to the latest available glasscord.asar file. No need to update it at each compiled ones, It take the latest `glasscord.asar`.
Example for It´s inclusion : https://canary.discordapp.com/channels/696696149301657640/696696671181996033/724729780368441434
- Added more warnings on the tutorial process in order to limit people from doing both cases at once.
	- Bold app.asar **OR** app folder warning.
	- Big text paragraph asking to read the README.md carefully
Example for It´s inclusion : https://canary.discordapp.com/channels/696696149301657640/696743152190488617/721485380100292699
- Node.js installation changes
	- Removed the sudo command from the npm install command.
	- Added a note about the needed administrative rights to get over the removed sudo command.
	- Added a note about the required node.js tools.
Example for It´s inclusion : #44 
- Discord installation notes changes
	- Explicitly stated the status of the glasscord CSS Loader for use with Discord.
	- Added links to known Discord themes loaders.
	- Added default discord installation folders. **I HAVEN´T TESTED THE DISCORD LOCATION FOR MACOS**.
Example for It´s inclusion : https://canary.discordapp.com/channels/696696149301657640/696696671181996033/725345622202253476
- Added more excuse for the Windows comportment on acrylic blur mode.
Example for It´s inclusion : https://canary.discordapp.com/channels/696696149301657640/696743152190488617/723251506962366557
- Added compiling instructions
Example for It´s inclusion : https://canary.discordapp.com/channels/696696149301657640/699218383907848305/712224529367433216